### PR TITLE
chore: remove latest tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,20 @@
 name: Publish to Image Registry
 
 on:
-  release:
-    types:
-      - published
   push:
     tags:
       - "v*"
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Image tag"
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -21,7 +28,7 @@ jobs:
             public.ecr.aws/t3w2s2c9/deno-relay
           tags: |
             type=ref,event=tag
-            type=raw,value=latest
+            type=raw,value=${{ inputs.version }},enable=${{ github.event_name != 'push' }}
       - uses: docker/setup-qemu-action@v2
         with:
           platforms: amd64,arm64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish to Image Registry
 
 on:
+  release:
+    types:
+      - published
   push:
     tags:
       - "v*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,6 @@ on:
       version:
         required: true
         type: string
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Image tag"
-        required: true
-        type: string
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,8 @@ jobs:
           images: |
             supabase/deno-relay
             public.ecr.aws/t3w2s2c9/deno-relay
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=tag
             type=raw,value=${{ inputs.version }},enable=${{ github.event_name != 'push' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,6 @@ jobs:
         uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: 18
-          extra_plugins: |
-            @semantic-release/commit-analyzer
-            @semantic-release/release-notes-generator
-            @semantic-release/github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,13 @@ jobs:
             @semantic-release/github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs:
+      - release
+    if: needs.release.outputs.published == 'true'
+    # Call publish explicitly because events from actions cannot trigger more actions
+    uses: ./.github/workflows/publish.yml
+    with:
+      version: v${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
`latest` tag on ECR cannot be overridden, resulting in push failure.