### PR TITLE
Add support for relaying websockets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ async function verifyJWT(jwt: string): Promise<boolean> {
 function sanitizeHeaders(headers: Headers): Headers {
   const sanitizedHeaders = new Headers();
   const headerDenyList = ["set-cookie"];
+
   headers.forEach((value, key) => {
     if (!headerDenyList.includes(key.toLowerCase())) {
       sanitizedHeaders.set(key, value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,9 @@ async function relayTo(req: Request): Promise<Response> {
 }
 
 function isWebsocketUpgrade(req: Request) {
-  return req.method === 'GET' && req.headers.get('upgrade')?.toLowerCase() === 'websocket';
+  return req.method === 'GET'
+    && req.headers.get('connection')?.toLowerCase() === 'upgrade'
+    && req.headers.get('upgrade')?.toLowerCase() === 'websocket';
 }
 
 async function relayWebsocket(ctx: Context) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ function getAuthToken(ctx: Context) {
   }
   const [bearer, token] = authHeader.split(" ");
   if (bearer !== "Bearer") {
-    ctx.throw(Status.Unauthorized, `Auth header is not "Bearer {token}"`);
+    ctx.throw(Status.Unauthorized, `Auth header is not 'Bearer {token}'`);
   }
   return token;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,28 +3,28 @@ import {
   Request,
   Status,
   Context,
-} from "https://deno.land/x/oak@v10.3.0/mod.ts";
-import * as jose from "https://deno.land/x/jose@v4.3.7/index.ts";
-import { config } from "https://deno.land/x/dotenv@v3.2.0/mod.ts";
+} from 'https://deno.land/x/oak@v10.3.0/mod.ts';
+import * as jose from 'https://deno.land/x/jose@v4.3.7/index.ts';
+import { config } from 'https://deno.land/x/dotenv@v3.2.0/mod.ts';
 
 const app = new Application();
 
-const X_FORWARDED_HOST = "x-forwarded-host";
+const X_FORWARDED_HOST = 'x-forwarded-host';
 
 const JWT_SECRET =
-  Deno.env.get("JWT_SECRET") ?? config({ safe: true }).JWT_SECRET;
+  Deno.env.get('JWT_SECRET') ?? config({ safe: true }).JWT_SECRET;
 const DENO_ORIGIN =
-  Deno.env.get("DENO_ORIGIN") ?? config({ safe: true }).DENO_ORIGIN;
+  Deno.env.get('DENO_ORIGIN') ?? config({ safe: true }).DENO_ORIGIN;
 const VERIFY_JWT =
-  (Deno.env.get("VERIFY_JWT") ?? config({ safe: true }).VERIFY_JWT) === "true";
+  (Deno.env.get('VERIFY_JWT') ?? config({ safe: true }).VERIFY_JWT) === 'true';
 
 function getAuthToken(ctx: Context) {
-  const authHeader = ctx.request.headers.get("authorization");
+  const authHeader = ctx.request.headers.get('authorization');
   if (!authHeader) {
-    ctx.throw(Status.Unauthorized, "Missing authorization header");
+    ctx.throw(Status.Unauthorized, 'Missing authorization header');
   }
-  const [bearer, token] = authHeader.split(" ");
-  if (bearer !== "Bearer") {
+  const [bearer, token] = authHeader.split(' ');
+  if (bearer !== 'Bearer') {
     ctx.throw(Status.Unauthorized, `Auth header is not 'Bearer {token}'`);
   }
   return token;
@@ -44,8 +44,7 @@ async function verifyJWT(jwt: string): Promise<boolean> {
 
 function sanitizeHeaders(headers: Headers): Headers {
   const sanitizedHeaders = new Headers();
-  const headerDenyList = ["set-cookie"];
-
+  const headerDenyList = ['set-cookie'];
   headers.forEach((value, key) => {
     if (!headerDenyList.includes(key.toLowerCase())) {
       sanitizedHeaders.set(key, value);
@@ -72,7 +71,7 @@ function patchedReq(req: Request): [URL, RequestInit] {
         [X_FORWARDED_HOST]: xHost,
       },
       body: (req.hasBody
-        ? req.body({ type: "stream" }).value
+        ? req.body({ type: 'stream' }).value
         : undefined) as unknown as BodyInit,
       method: req.method,
     },
@@ -84,13 +83,38 @@ async function relayTo(req: Request): Promise<Response> {
   return await fetch(url, init);
 }
 
+function isWebsocketUpgrade(req: Request) {
+  return req.method === 'GET' && req.headers.get('upgrade') === 'websocket';
+}
+
+async function relayWebsocket(ctx: Context) {
+  const [url] = patchedReq(ctx.request);
+
+  url.protocol = url.protocol.replace('http', 'ws');
+
+  await new Promise<void>((resolve) => {
+    const upstream = new WebSocket(url);
+    const downstream = ctx.upgrade();
+
+    upstream.onopen = () => {
+      upstream.onmessage = ({ data }) => downstream.send(data);
+      downstream.onmessage = ({ data }) => upstream.send(data);
+
+      resolve();
+    };
+
+    upstream.onclose = () => downstream.close();
+    downstream.onclose = () => upstream.close();
+  });
+}
+
 app.use(async (ctx: Context, next: () => Promise<unknown>) => {
   try {
     await next();
   } catch (err) {
     console.error(err);
     ctx.response.body = err.message;
-    ctx.response.headers.append("x-relay-error", "true");
+    ctx.response.headers.append('x-relay-error', 'true');
     ctx.response.status = err.status || 500;
   }
 });
@@ -98,36 +122,39 @@ app.use(async (ctx: Context, next: () => Promise<unknown>) => {
 app.use(async (ctx: Context, next: () => Promise<unknown>) => {
   const { request, response } = ctx;
 
-  if (!(request.method === "POST" || request.method === "OPTIONS")) {
+  if (!(request.method === 'POST' || request.method === 'OPTIONS' || isWebsocketUpgrade(request))) {
     console.error(`${request.method} not supported`);
     return ctx.throw(
       Status.MethodNotAllowed,
-      "Only POST and OPTIONS requests are supported"
+      'Only POST and OPTIONS requests are supported'
     );
   }
 
-  if (request.method !== "OPTIONS" && VERIFY_JWT) {
+  if (request.method !== 'OPTIONS' && VERIFY_JWT) {
     const token = getAuthToken(ctx);
     const isValidJWT = await verifyJWT(token);
 
     if (!isValidJWT) {
-      return ctx.throw(Status.Unauthorized, "Invalid JWT");
+      return ctx.throw(Status.Unauthorized, 'Invalid JWT');
     }
   }
 
-  const resp = await relayTo(request);
+  if (isWebsocketUpgrade(request)) {
+    await relayWebsocket(ctx);
+  } else {
+    const resp = await relayTo(request);
 
-  response.body = resp.body;
-  response.status = resp.status;
-  response.headers = sanitizeHeaders(resp.headers);
-  response.type = resp.type;
-
+    response.body = resp.body;
+    response.status = resp.status;
+    response.headers = sanitizeHeaders(resp.headers);
+    response.type = resp.type;
+  }
   await next();
 });
 
 if (import.meta.main) {
   const port = parseInt(Deno.args?.[0] ?? 8081);
-  const hostname = "0.0.0.0";
+  const hostname = '0.0.0.0';
 
   console.log(`Listening on http://${hostname}:${port}`);
   await app.listen({ port, hostname });

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ async function relayTo(req: Request): Promise<Response> {
 }
 
 function isWebsocketUpgrade(req: Request) {
-  return req.method === 'GET' && req.headers.get('upgrade') === 'websocket';
+  return req.method === 'GET' && req.headers.get('upgrade')?.toLowerCase() === 'websocket';
 }
 
 async function relayWebsocket(ctx: Context) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for relaying WebSockets with Edge Functions by allowing upgrade requests and then relaying messages between the two sockets.

## What is the current behavior?

Cannot establish WebSocket requests as `GET` requests return an unsupported error.

## What is the new behavior?

WebSockets are supported, while denying still denying normal `GET` requests.

## Additional context

This is a supported feature with Deno Deploy so unless there's some conflict with the implementation between Supabase <-> Deno Deploy this should work.

If you want me to add tests let me know, there wasn't any existing ones to use as a base.

https://deno.com/blog/deploy-streams#websockets

As a use-case, I'm using WebSockets for tunneling TCP connections, i.e. SSH/Telnet sessions, which doesn't quite fit within the new Multiplayer features as the other end of the channel is not a client/subscriber but a TCP socket which I don't have control over.