### PR TITLE
feat: use latest Deno docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM supabase/deno:v1.20.3
+FROM denoland/deno:v1.27.2
 
 EXPOSE 8081
 WORKDIR /app


### PR DESCRIPTION
## What kind of change does this PR introduce?

This updates the Docker image to use the latest Deno image instead of Supabase's fork.
