### PR TITLE
fix: deno docker tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:v1.27.2
+FROM denoland/deno:1.27.2
 
 EXPOSE 8081
 WORKDIR /app


### PR DESCRIPTION
## What kind of change does this PR introduce?

Previous commit had a typo in deno's docker tag (`1.27.2` instead of `v1.27.2)