### PR TITLE
feat: use Deno ARM 64 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:1.27.2
+FROM lukechannings/deno:v1.27.1
 
 EXPOSE 8081
 WORKDIR /app


### PR DESCRIPTION
## What kind of change does this PR introduce?

Switching the Deno base image to a ARM 64 fork (maintained here: https://github.com/LukeChannings/deno-arm64), so the docker image can be run on Apple Silicon machines.