### PR TITLE
feat: Upgrade to Deno 1.30.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukechannings/deno:v1.28.0
+FROM lukechannings/deno:v1.30.3
 
 EXPOSE 8081
 WORKDIR /app


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upgraded to Deno 1.30.3. Main benefit is the upgrade to TypeScript 4.9.x, which introduces `satisfies`.

## What is the current behavior?

Any attempts to deploy code making use of `satisfies` results in a syntax error.

## What is the new behavior?

TS 4.9 functionality is supported 😄

```
deno@5a7f7123b267:/app$ deno --version
deno 1.30.3 (release, aarch64-unknown-linux-gnu)
v8 10.9.194.5
typescript 4.9.4
```

**Note:** I'm on an M1, hence the architecture.

